### PR TITLE
fix ExampleGuiBlock bug

### DIFF
--- a/src/main/java/github/flandre/examplemod/common/block/ExampleGuiBlock.java
+++ b/src/main/java/github/flandre/examplemod/common/block/ExampleGuiBlock.java
@@ -45,6 +45,9 @@ public class ExampleGuiBlock extends Block {
             if(tileEntity instanceof ExampleGuiTileEntity){
                 NetworkHooks.openGui((ServerPlayerEntity) player,(ExampleGuiTileEntity) tileEntity,pos);
             }
+        }else{
+            // 客户端需要返回SUCCESS, 否则会执行玩家手持物品的右键操作
+            return ActionResultType.SUCCESS;
         }
         return super.onBlockActivated(state, worldIn, pos, player, handIn, hit);
     }


### PR DESCRIPTION
如果这里没有返回success，那么客户端会执行玩家手持物品的右键操作。举个例子，如果玩家手持食物右键了这个block，如果不返回success，那么玩家会开始吃手持的食物，直到吃完一个，gui的启动并不会中断这一行为。